### PR TITLE
docs: add standardized sponsor support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@
 
 **Botanica will be free forever.** No asterisks. No "free for now." No pivot to paid.
 
+### 💝 Support Botanica
+
+🚀 **If Botanica helps you, consider [sponsoring](https://github.com/sponsors/Michael-A-Kuykendall) — 100% of support goes to keeping it free forever.**
+
+- **$5/month**: Coffee Hero ☕ — Eternal gratitude + name in [SPONSORS.md](SPONSORS.md)
+- **$25/month**: Developer Supporter 🐛 — Priority bug response + roadmap influence
+- **$100/month**: Corporate Backer 🏢 — Logo in README + release-note recognition
+- **$500/month**: Enterprise Partner 🚀 — Prominent logo + monthly office hours + roadmap input
+
+[**🎯 Become a Sponsor**](https://github.com/sponsors/Michael-A-Kuykendall) | See our amazing [sponsors](SPONSORS.md) 🙏
+
+**Thank you to our sponsors:** [ZephyrCloudIO](https://github.com/ZephyrCloudIO) (Corporate Backer) · alistairheath (Coffee Hero)
+
+---
+
 ## What is Botanica?
 
 Botanica is a **production-ready botanical database** that provides type-safe taxonomic management, cultivation tracking, and AI-powered plant insights. It's designed to be the **invisible infrastructure** that botanical applications just work with.

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,25 +1,67 @@
-# These amazing people make Botanica possible 🙏
+# Sponsors
 
-## Conservation Partners ($500+/month)
-*Your logo could be here*
+Thank you to all our sponsors who help keep Botanica free forever!
 
-## Institutional Backers ($100+/month)  
-*Your logo could be here*
+## Current Sponsors
 
-## Research Supporters ($25+/month)
-*Your logo could be here*
-
-## Coffee Heroes ($5+/month)
+### Enterprise Partners ($500+/month)
 *Be the first!*
 
----
+### Corporate Backers ($100+/month)
 
-**Want to support Botanica?** [Become a sponsor](https://github.com/sponsors/Michael-A-Kuykendall)
+[![ZephyrCloudIO](https://github.com/ZephyrCloudIO.png?size=80)](https://github.com/ZephyrCloudIO)
 
-Botanica is free forever, but your sponsorship helps me:
-- Fix bugs faster
+**[ZephyrCloudIO](https://github.com/ZephyrCloudIO)** - Corporate Backer (joined December 25th, 2025)
+
+### Developer Supporters ($25+/month)
+*Be the first!*
+
+### Coffee Heroes ($5+/month)
+- alistairheath
+
+## Why Sponsor?
+
+**Botanica is free forever.** No paid tiers, no enterprise upsells, no bait-and-switch.
+
+Your sponsorship helps:
+- Fix bugs faster with dedicated support
+- Improve documentation and examples
 - Add new features
-- Support more database backends
-- Keep botanical science moving forward
+- Expand test coverage across more platforms
 
-Every dollar matters. Every sponsor gets my eternal gratitude. 🌱
+## Sponsorship Tiers
+
+### Coffee Heroes - $5/month
+- Eternal gratitude
+- Sponsor badge on your GitHub profile
+- Name listed in this file
+
+### Developer Supporters - $25/month
+- Everything in Coffee Heroes
+- Priority response to bug reports
+- Name + link in SPONSORS.md
+- Influence on roadmap priorities
+
+### Corporate Backers - $100/month
+- Everything in Developer Supporters
+- Company logo in README (small)
+- Company logo in SPONSORS.md
+- Recognition in release notes
+
+### Enterprise Partners - $500+/month
+- Everything in Corporate Backers
+- Company logo in README (prominent placement)
+- Monthly 1:1 office hours
+- Direct input on roadmap
+- Early access to new features
+- Custom integration support
+
+## How to Sponsor
+
+[Become a Sponsor on GitHub](https://github.com/sponsors/Michael-A-Kuykendall)
+
+All sponsorship goes directly to maintaining Botanica and keeping it free forever.
+
+## Corporate Sponsorship
+
+For invoiced sponsorship or custom arrangements, email: michaelallenkuykendall@gmail.com


### PR DESCRIPTION
Adds the standardized 💝 Support Botanica section to README and standardizes SPONSORS.md (ZephyrCloudIO = Corporate Backer, alistairheath = Coffee Hero). Docs-only.